### PR TITLE
fix: ping registry root and support for NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,8 +13,15 @@ const MULTI_PUBLISH_FILE = '._multi-publish';
 
 class Exit extends Error {}
 
+const strictSSL = Boolean(Number.parseInt(process.env.NODE_TLS_REJECT_UNAUTHORIZED, 10));
+
 async function waitTillReachable(registry) {
-	if (await npmFetch('/-/ping', {registry}).catch(() => false)) {
+	const isReachable = await npmFetch('/', {
+		registry,
+		strictSSL,
+	}).catch(() => false);
+
+	if (isReachable) {
 		return;
 	}
 


### PR DESCRIPTION
In some cases, registries like Artifactory may not support the `/-/ping` end point. It's sufficient to just check the root path:

```
HttpErrorGeneral: 500 Internal Server Error - GET https://artifactory/api/npm/npm/-/ping
    at /npm-registry-fetch/check-response.js:95:15
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async waitTillReachable (/npm-multi-publish/lib/utils.js:17:12)
    at async prepublishOnly (/npm-multi-publish/lib/prepublish-only.js:23:2)
    at async /npm-multi-publish/bin/cli.js:23:3 {
  headers: [Object: null prototype] {
    date: [ 'Thu, 02 Sep 2021 04:23:21 GMT' ],
    'content-type': [ 'application/json' ],
    server: [ 'Artifactory/6.17.0' ],
    'x-artifactory-id': [ 'b9af3d3e2d81f52fdf72c12f9f6dfc48629bed5b' ],
    'x-artifactory-node-id': [ 'sf2p-sf2p-grn-artifactory-ha-master-0' ],
    'x-request-id': [ 'a5065e3f91b71c9a68c17f94a318b513' ],
    'transfer-encoding': [ 'chunked' ],
    'x-w-dc': [ 'SFO' ],
    'x-fetch-attempts': [ '1' ]
  },
  statusCode: 500,
  code: 'E500',
  method: 'GET',
  uri: 'https://artifactory/api/npm/npm/-/ping',
  body: { errors: [ [Object] ] },
  pkgid: 'ping'
}
```

